### PR TITLE
fix create-grid test

### DIFF
--- a/test/test_lights.clj
+++ b/test/test_lights.clj
@@ -48,7 +48,7 @@
 
 (deftest test-create-grid
   (let [xs (create-grid 25)]
-    (is (= (count xs)) 25)))
+    (is (= (count xs) 25))))
 
 (deftest test-number-of-rooms-on
   (is (= (number-of-rooms-on [:on :off :on :off :on :on])


### PR DESCRIPTION
This pull requests fixes an exception on test-create-grid. This error occurred because `(= )` function receives 2 parameters instead 1.
